### PR TITLE
Improve bot listening methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var (
 	config    Config
 	debugMode bool
 
-	botNameRgx  = regexp.MustCompile(`^\bmollie|\bmollie\??$`)
+	botNameRgx  = regexp.MustCompile(`^\bmollie(bot)\b|\bmollie(bot)\??$`)
 	helpRgx     = regexp.MustCompile(`\bhelp\b`)
 	lunchRgx    = regexp.MustCompile(`\blunch\w*|\beten\b|\beat\w*\b`)
 	thisWeekRgx = regexp.MustCompile(`\b(this|deze)\b\s+\bweek\b`)

--- a/main.go
+++ b/main.go
@@ -221,8 +221,8 @@ func manageResponse(msg *slack.MessageEvent) {
 		msg.Text = strings.Replace(msg.Text, tag, retrievedUsername, -1)
 	}
 
-	// Sentence starts or ends with 'mollie' or 'molliebot'
-	if botNameRgx.MatchString(msg.Text) {
+	// Sentence starts or ends with 'mollie' or 'molliebot' or is a direct message
+	if botNameRgx.MatchString(msg.Text) || IsMessageDM(msg) {
 		trimmedText := botNameRgx.ReplaceAllString(msg.Text, "")
 
 		//Handle help requests
@@ -312,6 +312,10 @@ func sendMessage(messageText string, channelId string) {
 		return
 	}
 	fmt.Printf("Message successfully sent to channel %s at %s\n", channelID, timestamp)
+}
+
+func IsMessageDM(msg *slack.MessageEvent) bool {
+	return regexp.MustCompile(`^D(.{8})$`).MatchString(msg.Channel)
 }
 
 func randomStringFromArray(array []string) string {

--- a/main.go
+++ b/main.go
@@ -34,12 +34,15 @@ var (
 	config    Config
 	debugMode bool
 
-	botNameRegex  = regexp.MustCompile(`^\bmollie(bot)\b|\bmollie(bot)\??$`)
-	helpRegex     = regexp.MustCompile(`\bhelp\b`)
-	lunchRegex    = regexp.MustCompile(`\blunch\w*|\beten\b|\beat\w*\b`)
-	thisWeekRegex = regexp.MustCompile(`\b(this|deze)\b\s+\bweek\b`)
-	todayRegex    = regexp.MustCompile(`\bvandaag\b|\btoday\b`)
-	userTagRegex  = regexp.MustCompile(`\<\@(.{9})\>`)
+	botNameRegex       = regexp.MustCompile(`^\bmollie(bot)\b|\bmollie(bot)\??$`)
+	helpRegex          = regexp.MustCompile(`\bhelp\b`)
+	lunchRegex         = regexp.MustCompile(`\blunch\w*|\beten\b|\beat\w*\b`)
+	thisWeekRegex      = regexp.MustCompile(`\b(this|deze)\b\s+\bweek\b`)
+	todayRegex         = regexp.MustCompile(`\bvandaag\b|\btoday\b`)
+	userTagRegex       = regexp.MustCompile(`\<\@(.{9})\>`)
+	goAwayRegex        = regexp.MustCompile(`(\bgo\b\s+\baway\b|\bleave\b|\bfuck\b\s+\boff\b)`)
+	userIdRegex        = regexp.MustCompile(`\<\@|\>`)
+	directMessageRegex = regexp.MustCompile(`^D(.{8})$`)
 
 	lunchNotFoundMessages = []string{
 		"404 Lunch not found",
@@ -236,7 +239,6 @@ func manageResponse(msg *slack.MessageEvent) {
 
 		//Handle general requests
 		// Sentence contains 'go' and 'away'
-		goAwayRegex := regexp.MustCompile(`(\bgo\b\s+\baway\b|\bleave\b|\bfuck\b\s+\boff\b)`)
 		if goAwayRegex.MatchString(trimmedText) == true {
 
 			sendMessage(fmt.Sprintf("I'm sorry %v, I'm afraid can't do that", retrieveSlackUsername(msg.User)), msg.Channel)
@@ -288,7 +290,7 @@ func retrieveSlackUsername(userId string) string {
 
 	// If userId contains <@ >, strip it from the string.
 	if userTagRegex.MatchString(userId) {
-		userId = regexp.MustCompile(`\<\@|\>`).ReplaceAllString(userId, "")
+		userId = userIdRegex.ReplaceAllString(userId, "")
 	}
 
 	user, error := api.GetUserInfo(userId)
@@ -315,7 +317,7 @@ func sendMessage(messageText string, channelId string) {
 }
 
 func IsDirectMessage(msg *slack.MessageEvent) bool {
-	return regexp.MustCompile(`^D(.{8})$`).MatchString(msg.Channel)
+	return directMessageRegex.MatchString(msg.Channel)
 }
 
 func randomStringFromArray(array []string) string {

--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func manageResponse(msg *slack.MessageEvent) {
 	}
 
 	// Sentence starts or ends with 'mollie' or 'molliebot' or is a direct message
-	if botNameRegex.MatchString(msg.Text) || IsMessageDM(msg) {
+	if botNameRegex.MatchString(msg.Text) || IsDirectMessage(msg) {
 		trimmedText := botNameRegex.ReplaceAllString(msg.Text, "")
 
 		//Handle help requests
@@ -314,7 +314,7 @@ func sendMessage(messageText string, channelId string) {
 	fmt.Printf("Message successfully sent to channel %s at %s\n", channelID, timestamp)
 }
 
-func IsMessageDM(msg *slack.MessageEvent) bool {
+func IsDirectMessage(msg *slack.MessageEvent) bool {
 	return regexp.MustCompile(`^D(.{8})$`).MatchString(msg.Channel)
 }
 

--- a/main.go
+++ b/main.go
@@ -34,12 +34,12 @@ var (
 	config    Config
 	debugMode bool
 
-	botNameRgx  = regexp.MustCompile(`^\bmollie(bot)\b|\bmollie(bot)\??$`)
-	helpRgx     = regexp.MustCompile(`\bhelp\b`)
-	lunchRgx    = regexp.MustCompile(`\blunch\w*|\beten\b|\beat\w*\b`)
-	thisWeekRgx = regexp.MustCompile(`\b(this|deze)\b\s+\bweek\b`)
-	todayRgx    = regexp.MustCompile(`\bvandaag\b|\btoday\b`)
-	userTagRgx  = regexp.MustCompile(`\<\@(.{9})\>`)
+	botNameRegex  = regexp.MustCompile(`^\bmollie(bot)\b|\bmollie(bot)\??$`)
+	helpRegex     = regexp.MustCompile(`\bhelp\b`)
+	lunchRegex    = regexp.MustCompile(`\blunch\w*|\beten\b|\beat\w*\b`)
+	thisWeekRegex = regexp.MustCompile(`\b(this|deze)\b\s+\bweek\b`)
+	todayRegex    = regexp.MustCompile(`\bvandaag\b|\btoday\b`)
+	userTagRegex  = regexp.MustCompile(`\<\@(.{9})\>`)
 
 	lunchNotFoundMessages = []string{
 		"404 Lunch not found",
@@ -215,19 +215,19 @@ func arrayContainsString(array []string, searchString string) bool {
 func manageResponse(msg *slack.MessageEvent) {
 
 	// Get <@U12345> tag(s) from text and convert them to readable names
-	userTags := userTagRgx.FindAllString(msg.Text, -1)
+	userTags := userTagRegex.FindAllString(msg.Text, -1)
 	for _, tag := range userTags {
 		retrievedUsername := retrieveSlackUsername(tag)
 		msg.Text = strings.Replace(msg.Text, tag, retrievedUsername, -1)
 	}
 
 	// Sentence starts or ends with 'mollie' or 'molliebot' or is a direct message
-	if botNameRgx.MatchString(msg.Text) || IsMessageDM(msg) {
-		trimmedText := botNameRgx.ReplaceAllString(msg.Text, "")
+	if botNameRegex.MatchString(msg.Text) || IsMessageDM(msg) {
+		trimmedText := botNameRegex.ReplaceAllString(msg.Text, "")
 
 		//Handle help requests
 		// Sentence contains 'help'
-		if helpRgx.MatchString(trimmedText) == true {
+		if helpRegex.MatchString(trimmedText) == true {
 			sendMessage("Need my help? Ask for lunch by asking along the lines of:\n"+
 				"> Mollie what's for lunch today\n"+
 				"> What are we having for lunch this week mollie\n"+
@@ -236,20 +236,20 @@ func manageResponse(msg *slack.MessageEvent) {
 
 		//Handle general requests
 		// Sentence contains 'go' and 'away'
-		goAwayRgx := regexp.MustCompile(`(\bgo\b\s+\baway\b|\bleave\b|\bfuck\b\s+\boff\b)`)
-		if goAwayRgx.MatchString(trimmedText) == true {
+		goAwayRegex := regexp.MustCompile(`(\bgo\b\s+\baway\b|\bleave\b|\bfuck\b\s+\boff\b)`)
+		if goAwayRegex.MatchString(trimmedText) == true {
 
 			sendMessage(fmt.Sprintf("I'm sorry %v, I'm afraid can't do that", retrieveSlackUsername(msg.User)), msg.Channel)
 		}
 
 		// Handle lunch requests
 		// Sentence contains 'lunch(ing,es)' or 'eten'
-		if lunchRgx.MatchString(trimmedText) == true {
+		if lunchRegex.MatchString(trimmedText) == true {
 
 			switch {
 
 			// Sentence contains 'this'/'deze' 'week'
-			case thisWeekRgx.MatchString(trimmedText):
+			case thisWeekRegex.MatchString(trimmedText):
 
 				lunchMessage := "This week the following is on the menu:\n"
 				lunches := getLunchThisWeek()
@@ -263,7 +263,7 @@ func manageResponse(msg *slack.MessageEvent) {
 				}
 			default:
 				// Sentence contains 'today'/'vandaag'
-				//todayRgx.MatchString(trimmedText):
+				//todayRegex.MatchString(trimmedText):
 
 				lunchFound := false
 				for _, lunch := range config.Lunch {
@@ -287,7 +287,7 @@ func manageResponse(msg *slack.MessageEvent) {
 func retrieveSlackUsername(userId string) string {
 
 	// If userId contains <@ >, strip it from the string.
-	if userTagRgx.MatchString(userId) {
+	if userTagRegex.MatchString(userId) {
 		userId = regexp.MustCompile(`\<\@|\>`).ReplaceAllString(userId, "")
 	}
 


### PR DESCRIPTION
A series of small improvements around the responsiveness of the bot

### Listening to both `mollie` and `molliebot` in a regular sentence
The bot regex was incomplete for this function, added `(bot)` to the regex to fix this.
Also added a missing `\b` to mark the end of the word. 

### Listening to the `@molliebot` handle
Fixes #11. The bot did not respond to `@molliebot`. When the following message is sent 
```
@molliebot hi there!
```
The slack real time API returns the following: 
```
"text":"<@U5DKAJ7QF> hi there!"
```
This `<@U1234568>` tag is now replaced by a username so it can be matched like a regular sentence.

### Listening to direct messages without using `mollie` in a sentence
Fixes #4. To achieve this, the channel id is retrieved from the message. When this ID starts with a `D`, then it's a direct message. If this matches -> then also respond without prefix
