### PR TITLE
Added kubernetes resources.yml, build and deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,29 @@ Required environment variables:
 
 Optional environment variables
 
+* `DEBUG` - `default: false`
+Enables or disables full debug log of the slack API in stdout
 * `CONFIG_LOCATION` - `default: './config.json'`
 The complete filepath where the bot should look for a config file.
 * `RESTRICT_TO_CONFIG_CHANNELS` - `default: false`
 This sets wheter the bot should respond to any channel it is invited in (`true`) or respond only to channels it has been invited in _and_ are set in the config file in the `channels` array.
+
+## Building and deployment
+Requirements:
+* [Expenv](https://github.com/blang/expenv)
+
+All scripts are located in the 'scripts/' directory. To build a new image you can run:
+
+    ./build.sh
+
+To build and immediately upload a new image to the docker hub and tag both `latest` and the current `gitref` use:
+
+    ./build.sh upload
+
+In order to deploy to the kubernetes cluster make sure you have the right cluster selected in your kube config and run:
+
+    ./deploy.sh production
+
+The parameter `production` can be replaced with `development`. For now the only difference in the state of the `DEBUG` env variable, for development it has been turned on.
+
+Variables in the `kubernetes.yml` are supported through [Expenv](https://github.com/blang/expenv).

--- a/kubernetes/resources.yml
+++ b/kubernetes/resources.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "molliebot-${ENVIRONMENT}"
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: molliebot
+  namespace: "molliebot-${ENVIRONMENT}"
+spec:
+  replicas: 1
+  minReadySeconds: 5
+  revisionHistoryLimit: 2 # this keeps 2 old replica sets, and removes older replica sets
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: molliebot
+    spec:
+      containers:
+      - image: registry.hub.docker.com/wvdeutekom/molliebot
+        name: molliebot
+        env:
+          - name: CONFIG_LOCATION
+            value: "/gopath/molliebot/config.json"
+          - name: RESTRICT_TO_CONFIG_CHANNELS
+            value: "false"
+          - name: API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: molliebot-secret
+                key: slack-api-key
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /gopath/molliebot
+          name: config
+      volumes:
+        - name: config
+          configMap:
+            name: molliebot-config
+            items:
+            - key: config-json
+              path: config.json
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: molliebot-secret
+  namespace: "molliebot-${ENVIRONMENT}"
+type: Opaque
+data:
+  slack-api-key: "${SLACK_API_KEY}"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: molliebot-config
+  namespace: molliebot-${ENVIRONMENT}
+data:
+  config-json: |
+    {
+      "channels": [
+        "C594N2UHG",
+        "C07J1HXF0"
+      ],
+      "lunch": [
+        { "date":"2017-05-24", "description":"Wortelkoolsalade, walnoten, gegrilde biet, peer, feta en groene kruidendressing" },
+        { "date":"2017-05-29", "description":"Rattatouille met heel veel groenten, kleine gehaktballetjes en zilvervlies rijst met yoghurt" },
+        { "date":"2017-05-31", "description":"Rode mulfilet op gestoofde bospeentjes, veel groene kruiden, kreeftenboter en een groenten freekehschotel met labneh" }
+      ]
+    }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+cd ../$( dirname "$0" )
+
+echo "Usage: ./build.sh [optional: 'upload']"
+
+GITREF=$(git rev-parse --short HEAD)
+IMAGE_ID=$(docker build . 2>/dev/null | awk '/Successfully built/{print $NF}')
+IMAGE_NAME='wvdeutekom/molliebot'
+
+docker tag $IMAGE_ID $IMAGE_NAME:$GITREF
+docker tag $IMAGE_ID $IMAGE_NAME:latest
+
+if [ "$1" == "upload" ]; then
+    scripts/upload.sh $IMAGE_NAME:$GITREF
+    scripts/upload.sh $IMAGE_NAME:latest
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ea
+
+if [ $# -ne 1 ]; then
+    echo 'Usage: ./deploy.sh [ENVIRONMENT]'
+    exit 1
+fi
+
+API_KEY=${API_KEY:?"You must set a API_KEY environment variable"}
+
+ENVIRONMENT=$1
+if [ -z "$ENVIRONMENT" ]; then
+    echo "Deploy to kubernetes using './deploy.sh [environment]'"
+    echo "For example 'kubernetes/deploy.sh production"
+    exit 1
+fi
+
+
+# Set env variables based on environment
+if [ "$ENVIRONMENT" == "production" ]; then
+    DEBUG="false"
+elif [ "$ENVIRONMENT" == "development" ]; then
+    DEBUG="true"
+else
+    echo 'Only deployment to production or development is supported at the moment'
+    exit 1;
+fi
+
+SLACK_API_KEY=$(echo -n $API_KEY | base64)
+expenv < ../kubernetes/resources.yml | kubectl --namespace=molliebot-${ENVIRONMENT} apply -f -

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo 'Usage: ./upload.sh [IMAGE_TAG]'
+    exit 1
+fi
+
+IMAGE_TAG=${1:?"You must provide a IMAGE_TAG as parameter to this script"}
+
+docker push $IMAGE_TAG


### PR DESCRIPTION
Added kubernetes resources.yml, build and deploy scripts.

The scripts in the `scripts` directory can now be used to build new images and deploy the molliebot.

Todo:
* [x] Update readme
* [x] Create an upload function (or script) to docker hub
* [x] Remove verbose bash execution `set -x` from scripts