### PR TITLE
Periodic lunch messages

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,9 @@
     "restricted_channels": [
       "C594N2UHG",
       "C07J1HXF0"
+    ],
+    "notification_times": [
+      "0 55 11 * * *"
     ]
   },
   "lunch": {
@@ -20,5 +23,3 @@
     ]
   }
 }
-
-

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
       "C07J1HXF0"
     ],
     "notification_times": [
-      "0 55 11 * * *"
+      "0 55 11 * * 1-5"
     ]
   },
   "lunch": {

--- a/lunch/lunch.go
+++ b/lunch/lunch.go
@@ -11,16 +11,30 @@ import (
 )
 
 var (
-	lunchNotFoundMessages = []string{
-		"404 Lunch not found",
-		"There will be bread.",
-		"Elementary, my dear Watson. It looks like bread.",
-		"Keep your friends close, but your bread closer.",
-		"Bread. Shaken, not stirred.",
+	introMessages = []string{
+		"Hi there! Are you as excited about lunch as I am? Let me see what's on the menu.",
+		"Hola, it's almost time for lunch! Let's see what I can hustle up.",
+	}
+
+	//LNF means Lunch Not Found
+	midLNFMessages = []string{
+		"Hmmm. I'm not sure what's on the menu today, all I can say is:",
+		"Don't see anything on the menu today, but my logs say:",
+		"Hmmm. I Couldn't find any lunchings. Slogan time!",
+		"No special lunch found, can someone insert my batteries? -BEEP-",
+		"Where is that lunch? Maybe you should try turning me off and on again",
+	}
+
+	postLNFMessages = []string{
+		`"404 Lunch not found" - Mollie monolith backend`,
+		`"There will be bread." - a bread fanatic`,
+		`"Elementary, my dear Watson. It looks like bread." - Mollie Holmes, probably.`,
+		`"Keep your friends close, but your bread closer." - Sun Tzu`,
+		`"Bread. Shaken, not stirred." - James Bread`,
 		"We'll always have bread.",
-		"They call it a royale with cheese. That means bread.",
-		"Nothing on the menu, but I will have my lunch, in this life or the next.",
-		"This bread seems somewhat familiar; have I eaten this before?",
+		`"They call it a royale with cheese. That means bread."`,
+		`"Nothing on the menu, but I will have my lunch, in this life or the next." - Me. 100%`,
+		`"This bread seems somewhat familiar; have I eaten this before?" - Captain Jack Sparrow`,
 	}
 )
 
@@ -42,14 +56,22 @@ func (lunches *Lunches) ConvertLunchStringsToDate() {
 	}
 }
 
-func (lunches *Lunches) GetLunchMessageOfToday() string {
+// GetLunchMessageOfToday Get the lunch message today.
+// If introduction is set to true then a short introduction message will be prepended
+func (lunches *Lunches) GetLunchMessageOfToday(introduction bool) string {
 
 	var lunchMessage string
 	lunchOfToday := lunches.getLunchOfToday()
 	if lunchOfToday != nil {
 		lunchMessage = "Today we eat: " + lunchOfToday.Description
 	} else {
-		lunchMessage = helpers.RandomStringFromArray(lunchNotFoundMessages)
+		if introduction {
+			lunchMessage += helpers.RandomStringFromArray(introMessages)
+			lunchMessage += "\n"
+		}
+		lunchMessage += helpers.RandomStringFromArray(midLNFMessages)
+		lunchMessage += "\n\n"
+		lunchMessage += helpers.RandomStringFromArray(postLNFMessages)
 	}
 	return lunchMessage
 }
@@ -64,12 +86,20 @@ func (lunches *Lunches) getLunchOfToday() *Lunch {
 	return nil
 }
 
-func (lunches *Lunches) GetLunchMessageOfThisWeek() string {
+// GetLunchMessageOfThisWeek Get the lunch message for this week.
+// If introduction is set to true then a short introduction message will be prepended
+func (lunches *Lunches) GetLunchMessageOfThisWeek(introduction bool) string {
 
 	lunchMessage := "This week the following is on the menu:\n"
 	availableLunch := lunches.getLunchOfThisWeek()
 	if len(availableLunch) == 0 {
-		lunchMessage = helpers.RandomStringFromArray(lunchNotFoundMessages)
+		if introduction {
+			lunchMessage += helpers.RandomStringFromArray(introMessages)
+			lunchMessage += "\n"
+		}
+		lunchMessage += helpers.RandomStringFromArray(midLNFMessages)
+		lunchMessage += "\n\n"
+		lunchMessage += helpers.RandomStringFromArray(postLNFMessages)
 	} else {
 		for _, lunch := range availableLunch {
 			lunchMessage += fmt.Sprintf("%v: %v\n", lunch.DateTime.Weekday(), lunch.Description)

--- a/lunch/lunch.go
+++ b/lunch/lunch.go
@@ -35,6 +35,7 @@ var (
 		`"They call it a royale with cheese. That means bread."`,
 		`"Nothing on the menu, but I will have my lunch, in this life or the next." - Me. 100%`,
 		`"This bread seems somewhat familiar; have I eaten this before?" - Captain Jack Sparrow`,
+		`"I'll always have bread, bread with peanutbutter." - Tjeerd`,
 	}
 )
 

--- a/lunch/lunch.go
+++ b/lunch/lunch.go
@@ -20,6 +20,7 @@ var (
 		"We'll always have bread.",
 		"They call it a royale with cheese. That means bread.",
 		"Nothing on the menu, but I will have my lunch, in this life or the next.",
+		"This bread seems somewhat familiar; have I eaten this before?",
 	}
 )
 
@@ -93,7 +94,6 @@ func (lunches *Lunches) getLunchOfThisWeek() []Lunch {
 		//Loop over each meal
 		for _, lunch := range lunches.Lunches {
 			if lunch.DateTime == day {
-				fmt.Printf("this week we eat: %v\n", lunch.Description)
 				lunchesThisWeek = append(lunchesThisWeek, lunch)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -106,14 +106,17 @@ func main() {
 func (context *AppContext) startCrons() {
 
 	cron := cron.New()
-	fmt.Println("adding cron")
-	cron.AddFunc("0 55 11 * * *", func() {
-		fmt.Println("Send CRON lunch message")
-		lunchMessage := context.Lunch.GetLunchMessageOfToday()
-		fmt.Println(lunchMessage)
+	for _, cronTime := range context.Message.NotificationTimes {
+		fmt.Println("adding cron ", cronTime)
+		cron.AddFunc(cronTime, func() {
+			fmt.Println("Send CRON lunch message")
+			lunchMessage := context.Lunch.GetLunchMessageOfToday()
+			fmt.Println(lunchMessage)
 
-		joinedChannelIDs := context.Message.GetJoinedChannelsIDs()
-		appContext.Message.SendMessageToChannels(lunchMessage, joinedChannelIDs)
-	})
+			joinedChannelIDs := context.Message.GetJoinedChannelsIDs()
+			context.Message.SendMessageToChannels(lunchMessage, joinedChannelIDs)
+		})
+
+	}
 	cron.Start()
 }

--- a/main.go
+++ b/main.go
@@ -109,9 +109,7 @@ func (context *AppContext) startCrons() {
 	for _, cronTime := range context.Message.NotificationTimes {
 		fmt.Println("adding cron ", cronTime)
 		cron.AddFunc(cronTime, func() {
-			fmt.Println("Send CRON lunch message")
-			lunchMessage := context.Lunch.GetLunchMessageOfToday()
-			fmt.Println(lunchMessage)
+			lunchMessage := context.Lunch.GetLunchMessageOfToday(true)
 
 			joinedChannelIDs := context.Message.GetJoinedChannelsIDs()
 			context.Message.SendMessageToChannels(lunchMessage, joinedChannelIDs)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/nlopes/slack"
+	"github.com/robfig/cron"
 	"github.com/spf13/viper"
 	"github.com/wvdeutekom/molliebot/lunch"
 	"github.com/wvdeutekom/molliebot/messages"
@@ -96,7 +97,23 @@ func main() {
 
 	logger := log.New(os.Stdout, "messages-bot: ", log.Lshortfile|log.LstdFlags)
 	slack.SetLogger(logger)
-
 	appContext.Message.Setup(appContext.Lunch)
+
+	appContext.startCrons()
 	appContext.Message.Monitor()
+}
+
+func (context *AppContext) startCrons() {
+
+	cron := cron.New()
+	fmt.Println("adding cron")
+	cron.AddFunc("0 55 11 * * *", func() {
+		fmt.Println("Send CRON lunch message")
+		lunchMessage := context.Lunch.GetLunchMessageOfToday()
+		fmt.Println(lunchMessage)
+
+		joinedChannelIDs := context.Message.GetJoinedChannelsIDs()
+		appContext.Message.SendMessageToChannels(lunchMessage, joinedChannelIDs)
+	})
+	cron.Start()
 }

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -160,6 +160,49 @@ func (m *Messages) RetrieveSlackUsername(userId string) string {
 	return user.Name
 }
 
+func (m *Messages) GetJoinedChannelsIDs() []string {
+
+	// Get Public channels that the user/bot is part of
+	allChannels := m.retrieveAllChannels()
+	// Also get the private channels. Only joined private channels can be fetched
+	allGroups := m.retrieveAllGroups()
+
+	var joinedChannels []string
+
+	// Loop through all the channels and add IDs to joinedChannels if IsMember
+	for _, v := range allChannels {
+		if v.IsMember {
+			joinedChannels = append(joinedChannels, v.ID)
+		}
+	}
+
+	// Add all group IDs to joinedChannels
+	for _, v := range allGroups {
+		joinedChannels = append(joinedChannels, v.ID)
+	}
+	return joinedChannels
+}
+
+func (m *Messages) retrieveAllChannels() []slack.Channel {
+	channels, error := m.api.GetChannels(true)
+	if error != nil {
+		fmt.Printf("retrievechannels error: %n\n", channels)
+		log.Print(error)
+		return nil
+	}
+	return channels
+}
+
+func (m *Messages) retrieveAllGroups() []slack.Group {
+	groups, error := m.api.GetGroups(true)
+	if error != nil {
+		fmt.Printf("retrieveallGroups error: %n\n", groups)
+		log.Print(error)
+		return nil
+	}
+	return groups
+}
+
 func (m *Messages) SendMessageToChannels(messageText string, channelIDs []string) {
 	for _, channelID := range channelIDs {
 		m.SendMessage(messageText, channelID)

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -3,10 +3,8 @@ package messages
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/nlopes/slack"
 	"github.com/wvdeutekom/molliebot/helpers"
@@ -241,8 +239,6 @@ func randomFooter() string {
 		"(•‿•) ",
 		"(」ﾟﾛﾟ)｣ ",
 	}
-
-	rand.Seed(time.Now().UTC().UnixNano())
 
 	// Append some padding
 	footerString := fmt.Sprintf("\n\n%v\n", helpers.RandomStringFromArray(emojis))

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -110,7 +110,9 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 			m.SendMessage("Need my help? Ask for lunch by asking along the lines of:\n"+
 				"> Mollie what's for lunch today\n"+
 				"> What are we having for lunch this week mollie\n"+
-				"Or try asking me that in dutch, I'll probably listen.", msg.Channel)
+				"Or try asking me that in dutch, I'll probably listen.\n"+
+				"\n"+
+				"Suggestions, bugs? Create an issue on <https://github.com/wvdeutekom/molliebot|github.com>", msg.Channel)
 		}
 
 		//Handle general requests
@@ -185,7 +187,6 @@ func (m *Messages) GetJoinedChannelsIDs() []string {
 func (m *Messages) retrieveAllChannels() []slack.Channel {
 	channels, error := m.api.GetChannels(true)
 	if error != nil {
-		fmt.Printf("retrievechannels error: %n\n", channels)
 		log.Print(error)
 		return nil
 	}
@@ -195,7 +196,6 @@ func (m *Messages) retrieveAllChannels() []slack.Channel {
 func (m *Messages) retrieveAllGroups() []slack.Group {
 	groups, error := m.api.GetGroups(true)
 	if error != nil {
-		fmt.Printf("retrieveallGroups error: %n\n", groups)
 		log.Print(error)
 		return nil
 	}

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -26,10 +26,11 @@ var (
 )
 
 type Messages struct {
-	api           *slack.Client
-	References    references
-	Channels      []string `mapstructure:"restricted_channels"`
-	Configuration configuration
+	api               *slack.Client
+	References        references
+	Channels          []string `mapstructure:"restricted_channels"`
+	NotificationTimes []string `mapstructure:"notification_times"`
+	Configuration     configuration
 }
 
 type configuration struct {

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -131,13 +131,13 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 			// Sentence contains 'this'/'deze' 'week'
 			case thisWeekRegex.MatchString(trimmedText):
 
-				lunchMessage := m.References.Lunch.GetLunchMessageOfThisWeek()
+				lunchMessage := m.References.Lunch.GetLunchMessageOfThisWeek(false)
 				m.SendMessage(lunchMessage, msg.Channel)
 			default:
 				// Sentence contains 'today'/'vandaag'
 				//todayRegex.MatchString(trimmedText):
 
-				lunchMessage := m.References.Lunch.GetLunchMessageOfToday()
+				lunchMessage := m.References.Lunch.GetLunchMessageOfToday(false)
 				m.SendMessage(lunchMessage, msg.Channel)
 			}
 		}


### PR DESCRIPTION
Added periodic messaging in this PR.

Changes:
- Added cron, now a periodic message can be sent to all subscribed channels. This is configured in the json config file
  - Every time a periodic message is sent the api is checked for joined public and private channels
  - After collection is done the lunch message for that day is sent to all those channels
- Added new lunch messages, these are now concatenated using several arrays of lunch messages:
  - `introMessages` that can be optionally prepended to any lunchmessage
  - `midLNFMessages` general lunch not found messages
  - `postLNFMessages` quotes that are appended after the mid section
- 