### PR TITLE
Basic Pagerduty integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+.vscode/
 .DS_Store
 api_key.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Molliebot
 
-Try asking the molliebot what's for lunch today.
+Try asking the molliebot what's for lunch or who is on-call today.
 
 
 ## Setup
 Required environment variables:
 
 * `API_KEY` - `default: empty`
+* `PAGERDUTY_API_KEY` - `default: empty`
 
 Optional environment variables
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,9 @@
 {
+  "pagerduty": {
+    "channels": [
+      "C594N2UHG"
+    ]
+  },
   "messages": {
     "restricted_channels": [
       "C594N2UHG",

--- a/kubernetes/resources.yml
+++ b/kubernetes/resources.yml
@@ -74,6 +74,11 @@ metadata:
 data:
   config-json: |
     {
+      "pagerduty": {
+        "channels": [
+          ""
+        ]
+      },
       "messages": {
         "restricted_channels": [
           "C594N2UHG",

--- a/lunch.go
+++ b/lunch.go
@@ -1,4 +1,4 @@
-package lunch
+package main
 
 import (
 	"fmt"
@@ -51,6 +51,10 @@ type Lunch struct {
 	Description string `mapstructure:"description"`
 }
 
+func (lunch *Lunches) Setup() {
+	appContext.Lunch.ConvertLunchStringsToDate()
+}
+
 func (lunches *Lunches) ConvertLunchStringsToDate() {
 	for i := 0; i < len(lunches.Lunches); i++ {
 		lunches.Lunches[i].DateTime = dates.StringToDate(lunches.Lunches[i].DateString)
@@ -61,6 +65,7 @@ func (lunches *Lunches) ConvertLunchStringsToDate() {
 // If introduction is set to true then a short introduction message will be prepended
 func (lunches *Lunches) GetLunchMessageOfToday(introduction bool) string {
 
+	fmt.Println("after")
 	var lunchMessage string
 	lunchOfToday := lunches.getLunchOfToday()
 	if lunchOfToday != nil {

--- a/lunch.go
+++ b/lunch.go
@@ -65,7 +65,6 @@ func (lunches *Lunches) ConvertLunchStringsToDate() {
 // If introduction is set to true then a short introduction message will be prepended
 func (lunches *Lunches) GetLunchMessageOfToday(introduction bool) string {
 
-	fmt.Println("after")
 	var lunchMessage string
 	lunchOfToday := lunches.getLunchOfToday()
 	if lunchOfToday != nil {

--- a/main.go
+++ b/main.go
@@ -9,14 +9,14 @@ import (
 	"github.com/nlopes/slack"
 	"github.com/robfig/cron"
 	"github.com/spf13/viper"
-	"github.com/wvdeutekom/molliebot/lunch"
-	"github.com/wvdeutekom/molliebot/messages"
+	"github.com/wvdeutekom/molliebot/schedules"
 )
 
 type AppContext struct {
-	Message *messages.Messages `mapstructure:"messages"`
-	Lunch   *lunch.Lunches     `mapstructure:"lunch"`
-	Options options
+	Message   *Messages `mapstructure:"messages"`
+	Lunch     *Lunches  `mapstructure:"lunch"`
+	Schedules *schedules.Context
+	Options   options
 }
 
 type options struct {
@@ -29,6 +29,8 @@ var (
 )
 
 func init() {
+	fmt.Println("init main!")
+
 	// Read config file
 	var configLocation string
 	if configLocation = os.Getenv("CONFIG_LOCATION"); configLocation == "" {
@@ -93,14 +95,18 @@ func init() {
 func main() {
 	fmt.Println("starting bot")
 
-	appContext.Lunch.ConvertLunchStringsToDate()
-
 	logger := log.New(os.Stdout, "messages-bot: ", log.Lshortfile|log.LstdFlags)
 	slack.SetLogger(logger)
-	appContext.Message.Setup(appContext.Lunch)
 
-	appContext.startCrons()
+	appContext.Lunch.Setup()
+	appContext.Message.Setup(&appContext)
+
+	// appContext.startCrons()
 	appContext.Message.Monitor()
+
+	var password string
+	print("waiting\n")
+	_, _ = fmt.Scanln(&password)
 }
 
 func (context *AppContext) startCrons() {

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ import (
 )
 
 type AppContext struct {
-	Message   *Messages `mapstructure:"messages"`
-	Lunch     *Lunches  `mapstructure:"lunch"`
-	Schedules *schedules.Context
-	Options   options
+	Message  *Messages `mapstructure:"messages"`
+	Lunch    *Lunches  `mapstructure:"lunch"`
+	Schedule *schedules.Client
+	Options  options
 }
 
 type options struct {
@@ -86,10 +86,14 @@ func init() {
 		}
 	}
 
+	// Pagerduty
+	pagerdutyApiKey := viper.Get("PAGERDUTY_API_KEY").(string)
+
 	appContext.Message.Configuration.ApiToken = apiToken
 	appContext.Options.DebugMode = debugMode
 	appContext.Message.Configuration.VerboseLogging = debugMode
 	appContext.Options.RestrictToConfigChannels = restrictToConfigChannels
+	appContext.Schedule = schedules.New(pagerdutyApiKey)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ var (
 )
 
 func init() {
-	fmt.Println("init main!")
-
 	// Read config file
 	var configLocation string
 	if configLocation = os.Getenv("CONFIG_LOCATION"); configLocation == "" {
@@ -87,6 +85,7 @@ func init() {
 	}
 
 	// Pagerduty
+	viper.BindEnv("PAGERDUTY_API_KEY")
 	pagerdutyApiKey := viper.Get("PAGERDUTY_API_KEY").(string)
 
 	appContext.Message.Configuration.ApiToken = apiToken
@@ -107,10 +106,6 @@ func main() {
 
 	// appContext.startCrons()
 	appContext.Message.Monitor()
-
-	var password string
-	print("waiting\n")
-	_, _ = fmt.Scanln(&password)
 }
 
 func (context *AppContext) startCrons() {

--- a/main.go
+++ b/main.go
@@ -104,13 +104,18 @@ func main() {
 	appContext.Lunch.Setup()
 	appContext.Message.Setup(&appContext)
 
-	// appContext.startCrons()
+	appContext.startCrons()
 	appContext.Message.Monitor()
 }
 
 func (context *AppContext) startCrons() {
 
 	cron := cron.New()
+
+	cron.AddFunc("0 */10 * * * *", func() {
+		context.Schedule.GetCurrentOnCallUsers()
+	})
+
 	for _, cronTime := range context.Message.NotificationTimes {
 		fmt.Println("adding cron ", cronTime)
 		cron.AddFunc(cronTime, func() {

--- a/messages.go
+++ b/messages.go
@@ -121,7 +121,7 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 		// Handle pagerduty requests
 		// Sentence contains on(-)call/pagerduty
 		if onCallRegex.MatchString(trimmedText) == true {
-			m.SendMessage("blaat", msg.Channel)
+			m.SendMessage(appContext.Schedule.GetCurrentOnCallUsersMessage(), msg.Channel)
 		}
 
 		// Handle lunch requests

--- a/messages.go
+++ b/messages.go
@@ -108,6 +108,9 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 				"> What are we having for lunch this week mollie\n"+
 				"Or try asking me that in dutch, I'll probably listen.\n"+
 				"\n"+
+				"I can also help you with pagerduty\n"+
+				"> Who is on call Molliebot?\n"+
+				"> Who has pagerduty today Mollie?\n"+
 				"Suggestions, bugs? Create an issue on <https://github.com/wvdeutekom/molliebot|github.com>", msg.Channel)
 		}
 

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -28,6 +28,8 @@ func (client *Client) GetCurrentOnCallUsersMessage() string {
 	onCallMessage := "Currently on call:\n"
 
 	var users []pagerduty.User
+
+	// For now, do not fetch new data every time this function is called. New data is fetched every 10 minutes in main.go to update this data.
 	if len(client.onCallUsers) > 0 {
 		users = client.onCallUsers
 	} else {

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
-	"github.com/spf13/viper"
 )
 
 type Client struct {
@@ -16,15 +15,8 @@ type Client struct {
 }
 
 //TODO:
-// * Chat: Get persons on call for a given date. Return the entire week and all the people on call in every team. USE client.ListOnCalls
+// * Chat: Get persons on call for a given date. E.g. "Who is on call next week", return the entire week and all the people on call in every team. USE client.ListOnCalls
 // * Administration: collect the entire pagerduty schedule from pagerduty. Make a list and send it to @wijnand every month
-
-// var authtoken = "P_-iGverwWGC7S7UgrsQ" // Set your auth token here
-
-func init() {
-	fmt.Println("init pagerduty!")
-	viper.BindEnv("PAGERDUTY_API_KEY")
-}
 
 func New(apiKey string) *Client {
 	client := &Client{}
@@ -67,7 +59,6 @@ func (client *Client) GetCurrentOnCallUsers() []pagerduty.User {
 		} else {
 			for _, user := range eps {
 				user = client.getUserInfo(user.ID)
-				fmt.Println(user)
 				onCallUsers = append(onCallUsers, user)
 			}
 		}
@@ -110,8 +101,6 @@ func (client *Client) storeSchedules(c <-chan pagerduty.Schedule) {
 }
 
 func (client *Client) getScheduleList() {
-	fmt.Println("getScheduleLIST: ")
-
 	if eps, err := client.pagerdutyClient.ListSchedules(pagerduty.ListSchedulesOptions{}); err != nil {
 		panic(err)
 	} else {
@@ -121,7 +110,6 @@ func (client *Client) getScheduleList() {
 
 func (client *Client) getSchedule(schedule pagerduty.Schedule, c chan<- pagerduty.Schedule) {
 
-	fmt.Println("START! --------------------", schedule.ID)
 	if schedule, err := client.pagerdutyClient.GetSchedule(schedule.ID, pagerduty.GetScheduleOptions{}); err != nil {
 		log.Fatal(err)
 	} else {

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -1,0 +1,112 @@
+package schedules
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/spf13/viper"
+)
+
+type Context struct {
+	apiKey      string
+	client      *pagerduty.Client
+	Schedules   []pagerduty.Schedule
+	onCallUsers []pagerduty.User
+}
+
+//TODO:
+// * Chat: Get persons on call for a given date. Return the entire week and all the people on call in every team. USE client.ListOnCalls
+// * Administration: collect the entire pagerduty schedule from pagerduty. Make a list and send it to @wijnand every month
+
+// var authtoken = "P_-iGverwWGC7S7UgrsQ" // Set your auth token here
+
+func init() {
+	fmt.Println("init pagerduty!")
+	viper.BindEnv("PAGERDUTY_API_KEY")
+
+	var context Context
+	context.apiKey = viper.Get("PAGERDUTY_API_KEY").(string)
+	context.client = pagerduty.NewClient(context.apiKey)
+}
+
+func (context *Context) GetCurrentOnCallUsers() []pagerduty.User {
+
+	context.getAllSchedules(false)
+
+	var onCallUsers []pagerduty.User
+
+	for _, schedule := range context.Schedules {
+		var onCallOpts pagerduty.ListOnCallUsersOptions
+		var currentTime = time.Now()
+		onCallOpts.Since = currentTime.Format("2006-01-02T15:04:05Z07:00")
+		hours, _ := time.ParseDuration("1s")
+		onCallOpts.Until = currentTime.Add(hours).Format("2006-01-02T15:04:05Z07:00")
+
+		if eps, err := context.client.ListOnCallUsers(schedule.ID, onCallOpts); err != nil {
+			panic(err)
+		} else {
+			for _, user := range eps {
+				user = context.getUserInfo(user.ID)
+				fmt.Println(user)
+				onCallUsers = append(onCallUsers, user)
+			}
+		}
+	}
+
+	return onCallUsers
+}
+
+func (context *Context) getUserInfo(userID string) pagerduty.User {
+	if user, err := context.client.GetUser(userID, pagerduty.GetUserOptions{}); err != nil {
+		panic(err)
+	} else {
+		return *user
+	}
+}
+func (context *Context) updatePagerdutyChannels() {
+
+	for _, schedule := range context.Schedules {
+		fmt.Println(schedule.FinalSchedule)
+	}
+}
+
+func (context *Context) getAllSchedules(withDetail bool) {
+	var c chan pagerduty.Schedule = make(chan pagerduty.Schedule)
+	context.getScheduleList()
+
+	if withDetail {
+		for _, schedule := range context.Schedules {
+			go context.getSchedule(schedule, c)
+		}
+		context.storeSchedules(c)
+	}
+}
+
+func (context *Context) storeSchedules(c <-chan pagerduty.Schedule) {
+	for i, _ := range context.Schedules {
+		schedule := <-c
+		context.Schedules[i] = schedule
+	}
+}
+
+func (context *Context) getScheduleList() {
+	fmt.Println("getScheduleLIST: ")
+
+	if eps, err := context.client.ListSchedules(pagerduty.ListSchedulesOptions{}); err != nil {
+		panic(err)
+	} else {
+		context.Schedules = eps.Schedules
+	}
+}
+
+func (context *Context) getSchedule(schedule pagerduty.Schedule, c chan<- pagerduty.Schedule) {
+
+	fmt.Println("START! --------------------", schedule.ID)
+	if schedule, err := context.client.GetSchedule(schedule.ID, pagerduty.GetScheduleOptions{}); err != nil {
+		log.Fatal(err)
+	} else {
+		c <- *schedule
+	}
+}


### PR DESCRIPTION
In this PR:
* Users can ask who is on-call at the moment
* Packages `messages` and `lunch` are now part of the `main` package. They were too tightly coupled to be separate packages.
* Added some code to fetch schedules in preperation of actually processing them at the end of each month.

This is not perfect yet, we should consider implementing a storage layer (database like rethinkdb?) into the bot to store pagerduty schedules and other settings.

In the next few PRs I want to move to a more loosely coupled system, initialising packages like `schedules.New(pagerdutyApiKey)` that returns an instance that can be used.
