### PR TITLE
Pagerduty generate report

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "pagerduty": {
-    "channels": [
-      "C594N2UHG"
+    "report_channels": [
+      "D5C4Z6DPA"
     ]
   },
   "messages": {
@@ -9,9 +9,7 @@
       "C594N2UHG",
       "C07J1HXF0"
     ],
-    "notification_times": [
-      "0 55 11 * * 1-5"
-    ]
+    "notification_times": []
   },
   "lunch": {
     "lunches": [

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -1,19 +1,30 @@
 package dates
 
 import (
-	"time"
 	"fmt"
+	"time"
 )
+
+type StringToDateOptions struct {
+	Format string
+}
 
 func IsStringToday(stringDate string) bool {
 
-	date := StringToDate(stringDate)
+	date := StringToDate(stringDate, StringToDateOptions{})
 	return IsDateToday(date)
 }
 
-func StringToDate(stringDate string) time.Time {
+func StringToDate(stringDate string, options StringToDateOptions) time.Time {
 
-	date, err := time.Parse("2006-01-02", stringDate)
+	var dateFormat string
+	if options.Format != "" {
+		dateFormat = options.Format
+	} else {
+		dateFormat = "2006-01-02"
+	}
+
+	date, err := time.Parse(dateFormat, stringDate)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/kubernetes/resources.yml
+++ b/kubernetes/resources.yml
@@ -81,8 +81,8 @@ data:
   config-json: |
     {
       "pagerduty": {
-        "channels": [
-          ""
+        "report_channels": [
+          "G6ARE3RSL"
         ]
       },
       "messages": {

--- a/lunch.go
+++ b/lunch.go
@@ -57,7 +57,7 @@ func (lunch *Lunches) Setup() {
 
 func (lunches *Lunches) ConvertLunchStringsToDate() {
 	for i := 0; i < len(lunches.Lunches); i++ {
-		lunches.Lunches[i].DateTime = dates.StringToDate(lunches.Lunches[i].DateString)
+		lunches.Lunches[i].DateTime = dates.StringToDate(lunches.Lunches[i].DateString, dates.StringToDateOptions{})
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -116,6 +116,13 @@ func (context *AppContext) startCrons() {
 		context.Schedule.GetCurrentOnCallUsers()
 	})
 
+	cron.AddFunc("0 1 11 18 * *", func() {
+		reportMessage := context.Schedule.CompileScheduleReport()
+
+		// Send message to private pagerduty_reports channel
+		context.Message.SendMessage(reportMessage, "G6ARE3RSL")
+	})
+
 	for _, cronTime := range context.Message.NotificationTimes {
 		fmt.Println("adding cron ", cronTime)
 		cron.AddFunc(cronTime, func() {

--- a/messages.go
+++ b/messages.go
@@ -125,10 +125,11 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 		// Handle pagerduty requests
 		// Sentence contains on(-)call/pagerduty
 		if onCallRegex.MatchString(trimmedText) == true {
-			if reportRegex.MatchString(trimmedText) == true {
+			// If question comes from report_channels array, return pagerduty report.
+			if (reportRegex.MatchString(trimmedText) && helpers.ArrayContainsString(appContext.Schedule.ReportChannels, msg.Channel)) == true {
 				m.SendMessage(appContext.Schedule.CompileScheduleReport(), msg.Channel)
 			} else {
-				// If the user does not ask for a report, then print who is on call right now.
+				// If the user does not/may not ask for a report, then print who is on call right now.
 				m.SendMessage(appContext.Schedule.GetCurrentOnCallUsersMessage(), msg.Channel)
 			}
 		}

--- a/messages.go
+++ b/messages.go
@@ -20,6 +20,7 @@ var (
 	goAwayRegex        = regexp.MustCompile(`(\bgo\b\s+\baway\b|\bleave\b|\bfuck\b\s+\boff\b)`)
 	userIdRegex        = regexp.MustCompile(`\<\@|\>`)
 	onCallRegex        = regexp.MustCompile(`\bpagerduty\b|\bon(-| )?call\b`)
+	reportRegex        = regexp.MustCompile(`\breport\b`)
 	directMessageRegex = regexp.MustCompile(`^D(.{8})$`)
 )
 
@@ -124,7 +125,12 @@ func (m *Messages) manageResponse(msg *slack.MessageEvent) {
 		// Handle pagerduty requests
 		// Sentence contains on(-)call/pagerduty
 		if onCallRegex.MatchString(trimmedText) == true {
-			m.SendMessage(appContext.Schedule.GetCurrentOnCallUsersMessage(), msg.Channel)
+			if reportRegex.MatchString(trimmedText) == true {
+				m.SendMessage(appContext.Schedule.CompileScheduleReport(), msg.Channel)
+			} else {
+				// If the user does not ask for a report, then print who is on call right now.
+				m.SendMessage(appContext.Schedule.GetCurrentOnCallUsersMessage(), msg.Channel)
+			}
 		}
 
 		// Handle lunch requests

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -110,7 +110,7 @@ func (client *Client) CompileScheduleReport() string {
 	location, _ := time.LoadLocation("Europe/Amsterdam")
 
 	nowTime := time.Now()
-	untilTime := time.Date(nowTime.Year(), nowTime.Month()-1, 18, 11, 01, 0, 0, location)
+	untilTime := time.Date(nowTime.Year(), nowTime.Month(), 18, 11, 01, 0, 0, location)
 	fromTime := untilTime.AddDate(0, -1, 0).Add(time.Minute)
 	fmt.Println(fromTime, untilTime)
 
@@ -123,7 +123,7 @@ func (client *Client) CompileScheduleReport() string {
 	// Get all on call information from pagerduty API: User, Schedule and Start/End dates
 	onCalls := client.listOncalls(fromTime, untilTime, scheduleIds...)
 
-	formattedReport := fmt.Sprintf("The following people have been on-call: \nTimeline:\n")
+	formattedReport := fmt.Sprintf("The following people have been on-call:\n\nTimeline from %s to %s:\n", fromTime.Format("2006-01-02 15:04"), untilTime.Format("2006-01-02 15:04"))
 
 	// Calculate the compensation for each onCall and add it to the formattedReport
 	for _, onCall := range onCalls {
@@ -146,6 +146,7 @@ func (client *Client) CompileScheduleReport() string {
 
 		}
 	}
+	formattedReport = formattedReport + "\nNote that _only_ the schedules that _end_ within this window are listed. Any on-call schedules exceeding this window will be taken into consideration next month."
 	fmt.Println(formattedReport)
 
 	return formattedReport

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -77,8 +77,8 @@ func (client *Client) GetCurrentOnCallUsers() []pagerduty.User {
 func (client *Client) listOncallUsers(scheduleId string, from time.Time, until time.Time) []pagerduty.User {
 
 	var onCallOpts pagerduty.ListOnCallUsersOptions
-	onCallOpts.Since = from.Format("2006-01-02T15:04:05Z07:00")
-	onCallOpts.Until = until.Format("2006-01-02T15:04:05Z07:00")
+	onCallOpts.Since = from.In(time.UTC).Format("2006-01-02T15:04:05Z07:00")
+	onCallOpts.Until = until.In(time.UTC).Format("2006-01-02T15:04:05Z07:00")
 
 	if users, err := client.pagerdutyClient.ListOnCallUsers(scheduleId, onCallOpts); err != nil {
 		panic(err)
@@ -94,7 +94,6 @@ func (client *Client) listOncalls(from time.Time, until time.Time, scheduleIds .
 	onCallOpts.Since = from.In(time.UTC).Format("2006-01-02T15:04:05Z07:00")
 	onCallOpts.Until = until.In(time.UTC).Format("2006-01-02T15:04:05Z07:00")
 	onCallOpts.ScheduleIDs = scheduleIds
-	fmt.Println(onCallOpts)
 
 	if listOnCallResponse, err := client.pagerdutyClient.ListOnCalls(onCallOpts); err != nil {
 		panic(err)
@@ -123,7 +122,7 @@ func (client *Client) CompileScheduleReport() string {
 	// Get all on call information from pagerduty API: User, Schedule and Start/End dates
 	onCalls := client.listOncalls(fromTime, untilTime, scheduleIds...)
 
-	formattedReport := fmt.Sprintf("The following people have been on-call:\n\nTimeline from %s to %s:\n", fromTime.Format("2006-01-02 15:04"), untilTime.Format("2006-01-02 15:04"))
+	formattedReport := fmt.Sprintf("The following people have been on call:\n\nTimeline from %s to %s:\n", fromTime.Format("2006-01-02 15:04"), untilTime.Format("2006-01-02 15:04"))
 
 	// Calculate the compensation for each onCall and add it to the formattedReport
 	for _, onCall := range onCalls {
@@ -147,7 +146,6 @@ func (client *Client) CompileScheduleReport() string {
 		}
 	}
 	formattedReport = formattedReport + "\nNote that _only_ the schedules that _end_ within this window are listed. Any on-call schedules exceeding this window will be taken into consideration next month."
-	fmt.Println(formattedReport)
 
 	return formattedReport
 }


### PR DESCRIPTION
Molliebot can now generate a pagerduty report of the last month.

Asking the molliebot for
> Molliebot give me the pagerduty report
It triggers on pagerduty+report in one sentence.

It will then output the people on call from the 18th last month to the 18th this month. The number of hours, weeks and outpayment per person is also noted.

For example:
```
2017-08-08 11:00 - 2017-08-15 11:00: John Connor for 168.00 hours, that's 1.000000 week(s) = €150.00
2017-08-08 11:00 - 2017-08-15 11:00: Isabel Armstrong for 168.00 hours, that's 1.000000 week(s) = €150.00
2017-08-11 11:00 - 2017-08-14 11:00: Brent West for 72.00 hours, that's 0.428571 week(s) = €64.29
2017-08-14 11:00 - 2017-08-15 11:00: Harriet Stone for 24.00 hours, that's 0.142857 week(s) = €21.43

Note that _only_ the schedules that _end_ within this window are listed. Any on-call schedules exceeding this window will be taken into consideration next month.
```

The above report is **only** available for the users in the correct channels. These channels are specified in the resources.yml under:
```
      "pagerduty": {
        "report_channels": [
          "D5C0A0AAA"
        ]
      }
```
