### PR TITLE
Added Pagerduty contact methods & Glide dependency manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .DS_Store
 api_key.json
+vendor/*

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,62 @@
+hash: 1b2a5e445f451103c6a64a43017761b11afc064f6d3e2529131a5ef10a897901
+updated: 2017-09-13T10:31:42.053922386+02:00
+imports:
+- name: github.com/fsnotify/fsnotify
+  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+- name: github.com/google/go-querystring
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
+  subpackages:
+  - query
+- name: github.com/grsmv/goweek
+  version: 523a631ad28c04485c02e046120dd9abff12de68
+- name: github.com/hashicorp/hcl
+  version: 8f6b1344a92ff8877cf24a5de9177bf7d0a2a187
+  subpackages:
+  - hcl/ast
+  - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
+  - hcl/token
+  - json/parser
+  - json/scanner
+  - json/token
+- name: github.com/magiconair/properties
+  version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
+- name: github.com/mitchellh/mapstructure
+  version: d0303fe809921458f417bcf828397a65db30a7e4
+- name: github.com/nlopes/slack
+  version: c86337c0ef2486a15edd804355d9c73d2f2caed1
+- name: github.com/pelletier/go-toml
+  version: 1d6b12b7cb290426e27e6b4e38b89fcda3aeef03
+- name: github.com/robfig/cron
+  version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
+- name: github.com/spf13/afero
+  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
+  subpackages:
+  - mem
+- name: github.com/spf13/cast
+  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
+- name: github.com/spf13/jwalterweatherman
+  version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
+- name: github.com/spf13/pflag
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/spf13/viper
+  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+- name: github.com/wvdeutekom/go-pagerduty
+  version: 5fc1b0b298beb44c7543c3bad054d06a347d2885
+- name: golang.org/x/net
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  subpackages:
+  - websocket
+- name: golang.org/x/sys
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - transform
+  - unicode/norm
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,11 @@
+package: github.com/wvdeutekom/molliebot
+import:
+- package: github.com/grsmv/goweek
+- package: github.com/nlopes/slack
+  version: ~0.1.0
+- package: github.com/robfig/cron
+  version: ~1.0.0
+- package: github.com/spf13/viper
+  version: ~1.0.0
+- package: github.com/wvdeutekom/go-pagerduty
+  version: add-user-contact-methods


### PR DESCRIPTION
This PR adds both Pagerduty contact methods and Glide dependency manager. 
Fixes #22 

Because the pagerduty library does not yet support the retrieval of contact methods I have forked that project, added it and created a PR to their git repo: https://github.com/PagerDuty/go-pagerduty/pull/91.

In the meantime we run on my fork to support this feature.
```
package: github.com/wvdeutekom/go-pagerduty
version: add-user-contact-methods
```

