### PR TITLE
Fixed version of go-pagerduty dependency

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,7 @@ import:
 - package: github.com/spf13/viper
   version: ~1.0.0
 - package: github.com/wvdeutekom/go-pagerduty
+  version: add-user-contact-methods
 - package: github.com/wvdeutekom/molliebot
   version: glide-dockerfile
   subpackages:


### PR DESCRIPTION
Fixed version of go-pagerduty dependency.
Added `version: add-user-contact-methods` to glide.yaml