### PR TITLE
Updated glide.lock and glide.yaml. Fixed pagerduty import mistake

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d06a5471997f44dba1aace9ef017e6d179e02a4a99a25bee9a48c8b63ad38d01
-updated: 2017-09-19T00:05:46.841676688+02:00
+hash: a427ace8bdec2320522f50dc38d6488198756f0070a7b27d98e975f6ada1ff38
+updated: 2017-10-04T22:57:52.970779106+02:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
@@ -26,12 +26,14 @@ imports:
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/nlopes/slack
   version: c86337c0ef2486a15edd804355d9c73d2f2caed1
+- name: github.com/PagerDuty/go-pagerduty
+  version: 078a3284fb0ee5256d2164b53b9ed44ff3b3b05e
 - name: github.com/pelletier/go-toml
-  version: 1d6b12b7cb290426e27e6b4e38b89fcda3aeef03
+  version: 2009e44b6f182e34d8ce081ac2767622937ea3d4
 - name: github.com/robfig/cron
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/spf13/afero
-  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
+  version: 3de492c3cda9570c77bc1f495857bfbf4b760efd
   subpackages:
   - mem
 - name: github.com/spf13/cast
@@ -39,30 +41,30 @@ imports:
 - name: github.com/spf13/jwalterweatherman
   version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: be7121dd7a937a85e1e4b1ddda6a3edce3466110
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/wvdeutekom/go-pagerduty
   version: 5fc1b0b298beb44c7543c3bad054d06a347d2885
 - name: github.com/wvdeutekom/molliebot
-  version: 0a30261b02dafe5f3af7203dd23a45d098529e3d
+  version: ccd12b0def4e1ab9fb4a10049bf9b2a987b62ddd
   subpackages:
   - dates
   - helpers
   - schedules
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
   subpackages:
   - websocket
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 314a259e304ff91bd6985da2a7149bbf91237993
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/wvdeutekom/go-pagerduty
   version: add-user-contact-methods
 - package: github.com/wvdeutekom/molliebot
-  version: glide-dockerfile
+  version: ^0.2.2
   subpackages:
   - schedules
   - helpers

--- a/schedules/schedules.go
+++ b/schedules/schedules.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/PagerDuty/go-pagerduty"
 	"github.com/spf13/viper"
+	"github.com/wvdeutekom/go-pagerduty"
 	"github.com/wvdeutekom/molliebot/dates"
 )
 


### PR DESCRIPTION
Updated glide.lock and glide.yaml. Fixed pagerduty import mistake.