### PR TITLE
Removed molliebot subpackages from glide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ENV GOROOT=/usr/lib/go \
     GOBIN=/gopath/bin \
     PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
-WORKDIR /gopath/src/app
-ADD . /gopath/src/app
-ENV GLIDE_HOME /gopath/src/app
+WORKDIR /gopath/src/github.com/wvdeutekom/molliebot
+ADD . /gopath/src/github.com/wvdeutekom/molliebot
+ENV GLIDE_HOME /gopath/src/github.com/wvdeutekom/molliebot
 
 # Install go and dependencies
 # Cleanup afterwards
@@ -28,4 +28,4 @@ RUN apk add tzdata && \
   echo "Europe/Amsterdam" >  /etc/timezone && \
   apk del tzdata
 
-CMD ["/gopath/bin/app"]
+CMD ["/gopath/bin/molliebot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apk add -U ca-certificates
 # Set the right timezone
 RUN apk add tzdata && \
   cp /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime && \
-  echo "Europe/Amsterdam" >  /etc/timezone && \
-  apk del tzdata
+  echo "Europe/Amsterdam" >  /etc/timezone
 
 CMD ["/gopath/bin/molliebot"]

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a427ace8bdec2320522f50dc38d6488198756f0070a7b27d98e975f6ada1ff38
-updated: 2017-10-04T22:57:52.970779106+02:00
+hash: 0463d22212bc5f221348dfa44509e1900945fead2c0efb0be9103253c202f324
+updated: 2017-10-05T18:19:31.184179402+02:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
@@ -26,8 +26,6 @@ imports:
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/nlopes/slack
   version: c86337c0ef2486a15edd804355d9c73d2f2caed1
-- name: github.com/PagerDuty/go-pagerduty
-  version: 078a3284fb0ee5256d2164b53b9ed44ff3b3b05e
 - name: github.com/pelletier/go-toml
   version: 2009e44b6f182e34d8ce081ac2767622937ea3d4
 - name: github.com/robfig/cron
@@ -46,12 +44,6 @@ imports:
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/wvdeutekom/go-pagerduty
   version: 5fc1b0b298beb44c7543c3bad054d06a347d2885
-- name: github.com/wvdeutekom/molliebot
-  version: ccd12b0def4e1ab9fb4a10049bf9b2a987b62ddd
-  subpackages:
-  - dates
-  - helpers
-  - schedules
 - name: golang.org/x/net
   version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
   subpackages:
@@ -61,7 +53,7 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
+  version: d82c1812e304abfeeabd31e995a115a2855bf642
   subpackages:
   - transform
   - unicode/norm

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,9 +9,3 @@ import:
   version: ~1.0.0
 - package: github.com/wvdeutekom/go-pagerduty
   version: add-user-contact-methods
-- package: github.com/wvdeutekom/molliebot
-  version: ^0.2.2
-  subpackages:
-  - schedules
-  - helpers
-  - dates


### PR DESCRIPTION
Also made dockerfile compatible with these changes. 
This gets rid of the subpackages that get pulled from its own repo. 